### PR TITLE
Error handling in case there's no event.message

### DIFF
--- a/src/shaka.js
+++ b/src/shaka.js
@@ -120,7 +120,9 @@ class Shaka extends Html5 {
     let code;
 
     // map the shaka player error to the appropriate video.js error
-    if (event.message.indexOf('UNSUPPORTED') > -1 || event.message.indexOf('NOT_SUPPORTED') > -1) {
+    if (!event.message) {
+        code = 2;
+    } else if (event.message.indexOf('UNSUPPORTED') > -1 || event.message.indexOf('NOT_SUPPORTED') > -1) {
       code = 4;
     } else {
       switch (event.category) {


### PR DESCRIPTION
I was getting this error when my video source failed to fetch (404):
```
Uncaught (in promise) TypeError: Cannot read property 'indexOf' of undefined
    at Shaka.retriggerError (videojs-shaka.js:474)
```

Event: https://i.imgur.com/hEGNldw.png

This pull request handles when `event` does not contain a message.