### PR TITLE
Add support for HLS

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
       player.reset();
       player.qualityPickerPlugin();
       player.src([{
-        type: stream.value.endsWith('m3u8') ? 'application/dash+xml' : 'application/x-mpegURL',
+        type: stream.value.endsWith('m3u8') ? 'application/x-mpegURL' : 'application/dash+xml',
         src: stream.value
       }]);
     });

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <input id="stream" type="text" value="https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd" style="width: 750px;"></input>
     <button id="play">Play</button>
   </div>
+  <script src="node_modules/mux.js/dist/mux.js"></script>
   <script src="node_modules/shaka-player/dist/shaka-player.compiled.debug.js"></script>
   <script src="node_modules/video.js/dist/video.js"></script>
   <script src="dist/videojs-shaka.js"></script>
@@ -37,8 +38,10 @@
     var play = document.getElementById('play');
 
     play.addEventListener('click', function() {
+      player.reset();
+      player.qualityPickerPlugin();
       player.src([{
-        type: 'application/dash+xml',
+        type: stream.value.endsWith('m3u8') ? 'application/dash+xml' : 'application/x-mpegURL',
         src: stream.value
       }]);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1806,12 +1806,12 @@
       }
     },
     "catharsis": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
-      "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
+      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
       "dev": true,
       "requires": {
-        "underscore-contrib": "~0.3.0"
+        "lodash": "^4.17.14"
       }
     },
     "chainsaw": {
@@ -6557,9 +6557,9 @@
       }
     },
     "linkify-it": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.1.0.tgz",
-      "integrity": "sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
       "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
@@ -6749,9 +6749,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash._reinterpolate": {
@@ -6994,9 +6994,9 @@
       }
     },
     "markdown-it-anchor": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.0.2.tgz",
-      "integrity": "sha512-AFM/woBI8QDJMS/9+MmsBMT5/AR+ImfOsunQZTZhzcTmna3rIzAzbOh5E0l6mlFM/i9666BpUtkqQ9bS7WApCg==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.5.tgz",
+      "integrity": "sha512-xLIjLQmtym3QpoY9llBgApknl7pxAcN3WDRc2d3rwpl+/YvDZHPmKscGs+L6E05xf2KrCXPBvosWt7MZukwSpQ==",
       "dev": true
     },
     "marked": {
@@ -8515,12 +8515,6 @@
             "ms": "^2.1.1"
           }
         },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -9294,20 +9288,12 @@
       "dev": true
     },
     "requizzle": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
-      "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
+      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
       "dev": true,
       "requires": {
-        "underscore": "~1.6.0"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-          "dev": true
-        }
+        "lodash": "^4.17.14"
       }
     },
     "resolve": {
@@ -10764,9 +10750,9 @@
       "dev": true
     },
     "uc.micro": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
-      "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
     },
     "uglify-js": {
@@ -10800,23 +10786,6 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
       "dev": true
-    },
-    "underscore-contrib": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
-      "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
-      "dev": true,
-      "requires": {
-        "underscore": "1.6.0"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-          "dev": true
-        }
-      }
     },
     "unherit": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -934,6 +934,13 @@
         "mux.js": "5.0.1",
         "url-toolkit": "^2.1.3",
         "video.js": "^6.8.0 || ^7.0.0"
+      },
+      "dependencies": {
+        "mux.js": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.0.1.tgz",
+          "integrity": "sha512-yfmJ9CaLGSyRnEwqwzvISSZe6EdcvXIsgapZfuNNFuUQUlYDwltnCgZqV6IG90daY4dYTemK/hxMoxI1bB6RjA=="
+        }
       }
     },
     "JSONStream": {
@@ -7275,9 +7282,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.0.1.tgz",
-      "integrity": "sha512-yfmJ9CaLGSyRnEwqwzvISSZe6EdcvXIsgapZfuNNFuUQUlYDwltnCgZqV6IG90daY4dYTemK/hxMoxI1bB6RjA=="
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.5.1.tgz",
+      "integrity": "sha512-5VmmjADBqS4++8pTI6poSRJ+chHdaoI4XErcQPM5w4QfwaDl+FQlSI0iOgWbYDn6CBCbDRKaSCcEiN2K5aHNGQ=="
     },
     "mz": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -83,8 +83,9 @@
   },
   "dependencies": {
     "global": "^4.3.2",
-    "video.js": "^6 || ^7",
-    "shaka-player": "~2.4.7"
+    "mux.js": "^5.5.1",
+    "shaka-player": "~2.4.7",
+    "video.js": "^6 || ^7"
   },
   "devDependencies": {
     "@videojs/generator-helpers": "~1.0.0",

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -172,7 +172,7 @@ Shaka.isSupported = function() {
 
 Shaka.canPlaySource = function(source, tech) {
 
-  const dashTypeRE = /^application\/dash\+xml/i;
+  const dashTypeRE = /^(application\/dash\+xml|application\/x-mpegURL)/i;
 
   if (dashTypeRE.test(source.type)) {
     return 'probably';


### PR DESCRIPTION
Adding support for HLS.  Also updating sample app to allow playing of HLS streams.  You can use the following HLS stream to test with http://cdnapi.kaltura.com/p/1878761/sp/187876100/playManifest/entryId/1_usagz19w/flavorIds/1_5spqkazq,1_nslowvhp,1_boih5aji,1_qahc37ag/format/applehttp/protocol/http/a.m3u8

Based on https://github.com/google/shaka-player/blob/master/docs/tutorials/faq.md, I needed to add mux.js to the sample app to get HLS working.

@wc-davide - please review this