### PR TITLE
Native playback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ npm-debug.log*
 # Dependency directories
 bower_components/
 node_modules/
+/node_modules
 
 # Build-related directories
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased (2020-07-26)
+* Added vagrant to ease the process of running the local demo for interactive development
+* Added compatibility with video.js v7.9.2
+* Verified compatibility with shaka-player 3.0.1
+* Added configuration options enableDash, enableHls, and overrideNative.
+* Added source handler - this replaces the default video.js source handlers
+* Deferred support check to shaka.Player.isBrowserSupported()
+* Added additional HLS mimetypes likely to be encountered per video.js
+* Added demos of new features
+
 ## 0.4.5 (2020-07-17)
 * Show label for text track if available (#26)
 * Bump lodash from 4.17.15 to 4.17.19 (#24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added additional HLS mimetypes likely to be encountered per video.js
 * Added demos of new features
 * Added option to automatically initialize the quality picker
+* Added playback for natively supported content via progressive download (mp4, webm, etc)
 
 ## 0.4.5 (2020-07-17)
 * Show label for text track if available (#26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Deferred support check to shaka.Player.isBrowserSupported()
 * Added additional HLS mimetypes likely to be encountered per video.js
 * Added demos of new features
+* Added option to automatically initialize the quality picker
 
 ## 0.4.5 (2020-07-17)
 * Show label for text track if available (#26)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We welcome contributions from everyone!
 
 ## Getting Started
 
-Make sure you have Node.js 8 or higher and npm installed.
+Make sure you have Node.js 10 or higher and npm installed.
 
 1. Fork this repository and clone your fork
 1. Install dependencies: `npm install`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We welcome contributions from everyone!
 
 ## Getting Started
 
-Make sure you have Node.js 10 or higher and npm installed.
+Make sure you have Node.js 8 or higher and npm installed.
 
 1. Fork this repository and clone your fork
 1. Install dependencies: `npm install`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ Make sure you have Node.js 8 or higher and npm installed.
 1. Install dependencies: `npm install`
 1. Run a development server: `npm start`
 
+Note: there is a vagrant configuration packaged with the project to make this easy
+
 ### Making Changes
 
 Refer to the [video.js plugin conventions][conventions] for more detail on best practices and tooling for video.js plugin authorship.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ If you need to set the DRM server after you initialize video.js prior to loading
 </script>
 ```
 
+### Playback configuration
+
+enableDash: null, false, or true (default) - null is a JSON serializable shortcut for `!videojs.browser.IS_ANY_SAFARI`
+enableHls: false, true (default)
+overrideNative: false, true - defaults to `!videojs.browser.IS_ANY_SAFARI` per videojs (https://github.com/videojs/http-streaming/issues/912)
+
 ### `qualitytrackchange` Event
 
 If you would like to know when a user switches video quality, you can register an event listener for `qualitytrackchange`.  The quality track object will be returned to you.

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ $ npm run sample
 
 Then just open the app at [http://localhost:3000/](http://localhost:3000/) 
 
+Note: there is a vagrant box available that provides a suitable runtime environment
+
 ## Special Thanks
 
 This library wasn't possible without leveraging the following libraries that were used to create this.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ If you need to set the DRM server after you initialize video.js prior to loading
 
 `enableHls`: false, true (default)
 
+`enableOther`: false, true (default) - playback of other natively supported content (i.e. mp4/webm via progressive download)
+
 `overrideNative`: false, true - defaults to `!videojs.browser.IS_ANY_SAFARI` per videojs (https://github.com/videojs/http-streaming/issues/912)
 
 `autoInitQualityPicker`: true, false (default) - when true the quality picker is automatically initialized

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ If you need to set the DRM server after you initialize video.js prior to loading
 enableDash: null, false, or true (default) - null is a JSON serializable shortcut for `!videojs.browser.IS_ANY_SAFARI`
 enableHls: false, true (default)
 overrideNative: false, true - defaults to `!videojs.browser.IS_ANY_SAFARI` per videojs (https://github.com/videojs/http-streaming/issues/912)
+autoInitQualityPicker: true, false (default) - when true the quality picker is automatically initialized
 
 ### `qualitytrackchange` Event
 

--- a/README.md
+++ b/README.md
@@ -157,10 +157,13 @@ If you need to set the DRM server after you initialize video.js prior to loading
 
 ### Playback configuration
 
-enableDash: null, false, or true (default) - null is a JSON serializable shortcut for `!videojs.browser.IS_ANY_SAFARI`
-enableHls: false, true (default)
-overrideNative: false, true - defaults to `!videojs.browser.IS_ANY_SAFARI` per videojs (https://github.com/videojs/http-streaming/issues/912)
-autoInitQualityPicker: true, false (default) - when true the quality picker is automatically initialized
+`enableDash`: null, false, or true (default) - null is a JSON serializable shortcut for `!videojs.browser.IS_ANY_SAFARI`
+
+`enableHls`: false, true (default)
+
+`overrideNative`: false, true - defaults to `!videojs.browser.IS_ANY_SAFARI` per videojs (https://github.com/videojs/http-streaming/issues/912)
+
+`autoInitQualityPicker`: true, false (default) - when true the quality picker is automatically initialized
 
 ### `qualitytrackchange` Event
 

--- a/index.html
+++ b/index.html
@@ -34,6 +34,25 @@
             type="application/dash+xml"
         />
     </video>
+
+  <p>HLS via auto setup</p>
+    <video class="video-js vjs-default-skin" controls
+      data-setup='
+          {
+            "techOrder": [
+              "shaka"
+            ],
+            "shaka": {
+              "debug": true
+            }
+          }
+      '
+    >
+        <source
+            src="https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8"
+            type="application/vnd.apple.mpegurl"
+        />
+    </video>
   
   <script src="node_modules/mux.js/dist/mux.js"></script>
   <script src="node_modules/shaka-player/dist/shaka-player.compiled.debug.js"></script>

--- a/index.html
+++ b/index.html
@@ -78,6 +78,30 @@
         />
     </video>
     
+    <p>Dash (enableDash: false) + HLS via auto setup</p>
+    <video class="video-js vjs-default-skin" controls  width="800" height="450"
+      data-setup='
+          {
+            "techOrder": [
+              "shaka"
+            ],
+            "shaka": {
+              "debug": true,
+              "enableDash": false
+            }
+          }
+      '
+    >
+        <source
+            src="https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd"
+            type="application/dash+xml"
+        />
+        <source
+            src="https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8"
+            type="application/vnd.apple.mpegurl"
+        />
+    </video>
+    
     <p>HLS + Dash via auto setup</p>
     <video class="video-js vjs-default-skin" controls  width="800" height="450"
       data-setup='
@@ -87,6 +111,30 @@
             ],
             "shaka": {
               "debug": true
+            }
+          }
+      '
+    >
+        <source
+            src="https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8"
+            type="application/vnd.apple.mpegurl"
+        />
+        <source
+            src="https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd"
+            type="application/dash+xml"
+        />
+    </video>
+    
+    <p>HLS (enableHls: false) + Dash via auto setup</p>
+    <video class="video-js vjs-default-skin" controls  width="800" height="450"
+      data-setup='
+          {
+            "techOrder": [
+              "shaka"
+            ],
+            "shaka": {
+              "debug": true,
+              "enableHls": false
             }
           }
       '

--- a/index.html
+++ b/index.html
@@ -54,6 +54,26 @@
             type="application/vnd.apple.mpegurl"
         />
     </video>
+    
+    <p>overrideNative True via auto setup</p>
+    <video class="video-js vjs-default-skin" controls  width="800" height="450"
+      data-setup='
+          {
+            "techOrder": [
+              "shaka"
+            ],
+            "shaka": {
+              "debug": true,
+              "overrideNative": true
+            }
+          }
+      '
+    >
+        <source
+            src="https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8"
+            type="application/vnd.apple.mpegurl"
+        />
+    </video>
   
   <script src="node_modules/mux.js/dist/mux.js"></script>
   <script src="node_modules/shaka-player/dist/shaka-player.compiled.debug.js"></script>

--- a/index.html
+++ b/index.html
@@ -119,6 +119,30 @@
         />
     </video>
     
+    <p>enableDash null via auto setup</p>
+    <video class="video-js vjs-default-skin" controls  width="800" height="450"
+      data-setup='
+          {
+            "techOrder": [
+              "shaka"
+            ],
+            "shaka": {
+              "debug": true,
+              "enableDash": null
+            }
+          }
+      '
+    >
+        <source
+            src="https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd"
+            type="application/dash+xml"
+        />
+        <source
+            src="https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8"
+            type="application/vnd.apple.mpegurl"
+        />
+    </video>
+    
     <p>enableHls False via auto setup</p>
     <video class="video-js vjs-default-skin" controls  width="800" height="450"
       data-setup='

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
         />
     </video>
     
-    <p>overrideNative True via auto setup</p>
+    <p>Dash + HLS via auto setup</p>
     <video class="video-js vjs-default-skin" controls  width="800" height="450"
       data-setup='
           {
@@ -63,48 +63,7 @@
               "shaka"
             ],
             "shaka": {
-              "debug": true,
-              "overrideNative": true
-            }
-          }
-      '
-    >
-        <source
-            src="https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8"
-            type="application/vnd.apple.mpegurl"
-        />
-    </video>
-    
-    <p>overrideNative False via auto setup</p>
-    <video class="video-js vjs-default-skin" controls  width="800" height="450"
-      data-setup='
-          {
-            "techOrder": [
-              "shaka"
-            ],
-            "shaka": {
-              "debug": true,
-              "overrideNative": false
-            }
-          }
-      '
-    >
-        <source
-            src="https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8"
-            type="application/vnd.apple.mpegurl"
-        />
-    </video>
-    
-    <p>enableDash False via auto setup</p>
-    <video class="video-js vjs-default-skin" controls  width="800" height="450"
-      data-setup='
-          {
-            "techOrder": [
-              "shaka"
-            ],
-            "shaka": {
-              "debug": true,
-              "enableDash": false
+              "debug": true
             }
           }
       '
@@ -119,7 +78,7 @@
         />
     </video>
     
-    <p>enableDash null via auto setup</p>
+    <p>HLS + Dash via auto setup</p>
     <video class="video-js vjs-default-skin" controls  width="800" height="450"
       data-setup='
           {
@@ -127,32 +86,7 @@
               "shaka"
             ],
             "shaka": {
-              "debug": true,
-              "enableDash": null
-            }
-          }
-      '
-    >
-        <source
-            src="https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd"
-            type="application/dash+xml"
-        />
-        <source
-            src="https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8"
-            type="application/vnd.apple.mpegurl"
-        />
-    </video>
-    
-    <p>enableHls False via auto setup</p>
-    <video class="video-js vjs-default-skin" controls  width="800" height="450"
-      data-setup='
-          {
-            "techOrder": [
-              "shaka"
-            ],
-            "shaka": {
-              "debug": true,
-              "enableHls": false
+              "debug": true
             }
           }
       '

--- a/index.html
+++ b/index.html
@@ -55,6 +55,26 @@
         />
     </video>
     
+    <p>HLS (overrideNative: false) via auto setup</p>
+    <video class="video-js vjs-default-skin" controls  width="800" height="450"
+      data-setup='
+          {
+            "techOrder": [
+              "shaka"
+            ],
+            "shaka": {
+              "debug": true,
+              "overrideNative": false
+            }
+          }
+      '
+    >
+        <source
+            src="https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8"
+            type="application/vnd.apple.mpegurl"
+        />
+    </video>
+    
     <p>Dash + HLS via auto setup</p>
     <video class="video-js vjs-default-skin" controls  width="800" height="450"
       data-setup='

--- a/index.html
+++ b/index.html
@@ -170,6 +170,57 @@
             type="application/dash+xml"
         />
     </video>
+    
+    <p>Progressive download via auto setup</p>
+    <video class="video-js vjs-default-skin" controls  width="800" height="450"
+      data-setup='
+          {
+            "techOrder": [
+              "shaka"
+            ],
+            "shaka": {
+              "debug": true
+            }
+          }
+      '
+    >
+        <source
+            src="https://interactive-examples.mdn.mozilla.net/media/examples/flower.webm"
+            type="video/webm"
+        />
+        <source
+            src="https://interactive-examples.mdn.mozilla.net/media/examples/flower.mp4"
+            type="video/mp4"
+        />
+    </video>
+    
+    <p>Progressive download (enableOther: false) + HLS via auto setup</p>
+    <video class="video-js vjs-default-skin" controls  width="800" height="450"
+      data-setup='
+          {
+            "techOrder": [
+              "shaka"
+            ],
+            "shaka": {
+              "debug": true,
+              "enableOther": false
+            }
+          }
+      '
+    >
+        <source
+            src="https://interactive-examples.mdn.mozilla.net/media/examples/flower.webm"
+            type="video/webm"
+        />
+        <source
+            src="https://interactive-examples.mdn.mozilla.net/media/examples/flower.mp4"
+            type="video/mp4"
+        />
+        <source
+            src="https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8"
+            type="application/vnd.apple.mpegurl"
+        />
+    </video>
   
   <script src="node_modules/mux.js/dist/mux.js"></script>
   <script src="node_modules/shaka-player/dist/shaka-player.compiled.debug.js"></script>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link href="dist/videojs-shaka.css" rel="stylesheet">
 </head>
 <body>
+  <p>Triggered via code</p>
   <video id="videojs-shaka-player" class="video-js vjs-default-skin" controls>
   </video>
   <br/>
@@ -14,6 +15,26 @@
     <input id="stream" type="text" value="https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd" style="width: 750px;"></input>
     <button id="play">Play</button>
   </div>
+  
+  <p>Dash via auto setup</p>
+    <video class="video-js vjs-default-skin" controls
+      data-setup='
+          {
+            "techOrder": [
+              "shaka"
+            ],
+            "shaka": {
+              "debug": true
+            }
+          }
+      '
+    >
+        <source
+            src="https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd"
+            type="application/dash+xml"
+        />
+    </video>
+  
   <script src="node_modules/mux.js/dist/mux.js"></script>
   <script src="node_modules/shaka-player/dist/shaka-player.compiled.debug.js"></script>
   <script src="node_modules/video.js/dist/video.js"></script>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <p>(try hls with https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8)</p>
   </div>
   
-  <p>Dash via auto setup</p>
+  <p>Dash via auto setup with autoInitQualityPicker: true</p>
     <video class="video-js vjs-default-skin" controls width="800" height="450"
       data-setup='
           {
@@ -25,6 +25,7 @@
               "shaka"
             ],
             "shaka": {
+              "autoInitQualityPicker": true,
               "debug": true
             }
           }
@@ -36,7 +37,7 @@
         />
     </video>
 
-  <p>HLS via auto setup</p>
+  <p>HLS via auto setup with autoInitQualityPicker: true</p>
     <video class="video-js vjs-default-skin" controls  width="800" height="450"
       data-setup='
           {
@@ -44,6 +45,7 @@
               "shaka"
             ],
             "shaka": {
+              "autoInitQualityPicker": true,
               "debug": true
             }
           }

--- a/index.html
+++ b/index.html
@@ -74,6 +74,26 @@
             type="application/vnd.apple.mpegurl"
         />
     </video>
+    
+    <p>overrideNative False via auto setup</p>
+    <video class="video-js vjs-default-skin" controls  width="800" height="450"
+      data-setup='
+          {
+            "techOrder": [
+              "shaka"
+            ],
+            "shaka": {
+              "debug": true,
+              "overrideNative": false
+            }
+          }
+      '
+    >
+        <source
+            src="https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8"
+            type="application/vnd.apple.mpegurl"
+        />
+    </video>
   
   <script src="node_modules/mux.js/dist/mux.js"></script>
   <script src="node_modules/shaka-player/dist/shaka-player.compiled.debug.js"></script>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link href="dist/videojs-shaka.css" rel="stylesheet">
 </head>
 <body>
-  <p>Triggered via code</p>
+  <p>Dash via code</p>
   <video id="videojs-shaka-player" class="video-js vjs-default-skin" controls>
   </video>
   <br/>
@@ -17,7 +17,7 @@
   </div>
   
   <p>Dash via auto setup</p>
-    <video class="video-js vjs-default-skin" controls
+    <video class="video-js vjs-default-skin" controls width="800" height="450"
       data-setup='
           {
             "techOrder": [
@@ -36,7 +36,7 @@
     </video>
 
   <p>HLS via auto setup</p>
-    <video class="video-js vjs-default-skin" controls
+    <video class="video-js vjs-default-skin" controls  width="800" height="450"
       data-setup='
           {
             "techOrder": [

--- a/index.html
+++ b/index.html
@@ -94,6 +94,54 @@
             type="application/vnd.apple.mpegurl"
         />
     </video>
+    
+    <p>enableDash False via auto setup</p>
+    <video class="video-js vjs-default-skin" controls  width="800" height="450"
+      data-setup='
+          {
+            "techOrder": [
+              "shaka"
+            ],
+            "shaka": {
+              "debug": true,
+              "enableDash": false
+            }
+          }
+      '
+    >
+        <source
+            src="https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd"
+            type="application/dash+xml"
+        />
+        <source
+            src="https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8"
+            type="application/vnd.apple.mpegurl"
+        />
+    </video>
+    
+    <p>enableHls False via auto setup</p>
+    <video class="video-js vjs-default-skin" controls  width="800" height="450"
+      data-setup='
+          {
+            "techOrder": [
+              "shaka"
+            ],
+            "shaka": {
+              "debug": true,
+              "enableHls": false
+            }
+          }
+      '
+    >
+        <source
+            src="https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8"
+            type="application/vnd.apple.mpegurl"
+        />
+        <source
+            src="https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd"
+            type="application/dash+xml"
+        />
+    </video>
   
   <script src="node_modules/mux.js/dist/mux.js"></script>
   <script src="node_modules/shaka-player/dist/shaka-player.compiled.debug.js"></script>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <div>
     <input id="stream" type="text" value="https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd" style="width: 750px;"></input>
     <button id="play">Play</button>
+    <p>(try hls with https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8)</p>
   </div>
   
   <p>Dash via auto setup</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -715,11 +715,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
-      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
+      "version": "7.10.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+      "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
       "requires": {
-        "regenerator-runtime": "^0.12.0"
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/template": {
@@ -923,23 +923,59 @@
       }
     },
     "@videojs/http-streaming": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-1.5.1.tgz",
-      "integrity": "sha512-Pc3aVr4SRINFLhUWjTofVjQ9iMjs9myXnyfJ0AdW0c4bLwJ0Fw7HUsbns+qseuBzVJe01i7J2R/DE1Y4hFgblA==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-1.13.3.tgz",
+      "integrity": "sha512-rOEShTytYchSxTKR5YvQ91mDN0b3BVOGoBSVzbgMbT8pOm2FEZ1G5dWuLtUpBnvFTPb0cxnTGmISwllPq3EWYg==",
       "requires": {
         "aes-decrypter": "3.0.0",
         "global": "^4.3.0",
-        "m3u8-parser": "4.2.0",
-        "mpd-parser": "0.7.0",
-        "mux.js": "5.0.1",
+        "m3u8-parser": "4.4.0",
+        "mpd-parser": "0.10.0",
+        "mux.js": "^5.5.3",
         "url-toolkit": "^2.1.3",
         "video.js": "^6.8.0 || ^7.0.0"
       },
       "dependencies": {
         "mux.js": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.0.1.tgz",
-          "integrity": "sha512-yfmJ9CaLGSyRnEwqwzvISSZe6EdcvXIsgapZfuNNFuUQUlYDwltnCgZqV6IG90daY4dYTemK/hxMoxI1bB6RjA=="
+          "version": "5.6.4",
+          "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.6.4.tgz",
+          "integrity": "sha512-k7UUafOn1axLqcnx0oF3xbTrVMXHd54ytwFHW30v+SRbZED63QjK7al+q9KMlF+NQOkydd+46xPqHk+ELZxL+g=="
+        }
+      }
+    },
+    "@videojs/vhs-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-1.3.0.tgz",
+      "integrity": "sha512-oiqXDtHQqDPun7JseWkirUHGrgdYdeF12goUut5z7vwAj4DmUufEPFJ4xK5hYGXGFDyDhk2rSFOR122Ze6qXyQ==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "global": "^4.3.2",
+        "url-toolkit": "^2.1.6"
+      }
+    },
+    "@videojs/xhr": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@videojs/xhr/-/xhr-2.5.1.tgz",
+      "integrity": "sha512-wV9nGESHseSK+S9ePEru2+OJZ1jq/ZbbzniGQ4weAmTIepuBMSYPx5zrxxQA0E786T5ykpO8ts+LayV+3/oI2w==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "global": "~4.4.0",
+        "is-function": "^1.0.1"
+      },
+      "dependencies": {
+        "global": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+          "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+          "requires": {
+            "min-document": "^2.19.0",
+            "process": "^0.11.10"
+          }
+        },
+        "process": {
+          "version": "0.11.10",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
         }
       }
     },
@@ -2878,6 +2914,11 @@
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
+    "eme-encryption-scheme-polyfill": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eme-encryption-scheme-polyfill/-/eme-encryption-scheme-polyfill-2.0.1.tgz",
+      "integrity": "sha512-Wz+Ro1c0/2Wsx2RLFvTOO0m4LvYn+7cSnq3XOvRvLLBq8jbvUACH/zpU9s0/5+mQa5oaelkU69x+q0z/iWYrFA=="
+    },
     "emoji-regex": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.3.tgz",
@@ -3864,14 +3905,6 @@
             "ms": "2.0.0"
           }
         }
-      }
-    },
-    "for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "requires": {
-        "is-callable": "^1.1.3"
       }
     },
     "for-in": {
@@ -5565,7 +5598,8 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
     },
     "is-ci": {
       "version": "2.0.0",
@@ -5679,9 +5713,9 @@
       }
     },
     "is-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
     "is-glob": {
       "version": "4.0.0",
@@ -6519,6 +6553,11 @@
       "integrity": "sha512-Ca1uhHGtNqUuzsnW3I+QykNuS/jF9vdxnIrkbLCVJRunCc6yWJq+ai1UobQT13j0e3JVUOf0mKo3QHZ6A6mG9Q==",
       "dev": true
     },
+    "keycode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
+      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -6934,9 +6973,12 @@
       }
     },
     "m3u8-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.2.0.tgz",
-      "integrity": "sha512-LVHw0U6IPJjwk9i9f7Xe26NqaUHTNlIt4SSWoEfYFROeVKHN6MIjOhbRheI3dg8Jbq5WCuMFQ0QU3EgZpmzFPg=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.4.0.tgz",
+      "integrity": "sha512-iH2AygTFILtato+XAgnoPYzLHM4R3DjATj7Ozbk7EHdB2XoLF2oyOUguM7Kc4UVHbQHHL/QPaw98r7PbWzG0gg==",
+      "requires": {
+        "global": "^4.3.2"
+      }
     },
     "magic-string": {
       "version": "0.25.1",
@@ -7253,12 +7295,14 @@
       "dev": true
     },
     "mpd-parser": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.7.0.tgz",
-      "integrity": "sha512-nkzVIkecaDz3q7p4ToN3GR0FV2Odbh0w2sJ8ijsyw79JcBrJoUD3KHIiI8gL0hEDlex7mrVpTxXBsRHowUBmPw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.10.0.tgz",
+      "integrity": "sha512-eIqkH/2osPr7tIIjhRmDWqm2wdJ7Q8oPfWvdjealzsLV2D2oNe0a0ae2gyYYs1sw5e5hdssDA2V6Sz8MW+Uvvw==",
       "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@videojs/vhs-utils": "^1.1.0",
         "global": "^4.3.2",
-        "url-toolkit": "^2.1.1"
+        "xmldom": "^0.1.27"
       }
     },
     "ms": {
@@ -8235,15 +8279,6 @@
         }
       }
     },
-    "parse-headers": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
-      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
-      "requires": {
-        "for-each": "^0.3.2",
-        "trim": "0.0.1"
-      }
-    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -9137,9 +9172,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.13.3",
@@ -9808,9 +9843,12 @@
       "dev": true
     },
     "shaka-player": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/shaka-player/-/shaka-player-2.4.7.tgz",
-      "integrity": "sha512-KXYVB7snrrmcmDvusf2IIGOXZCvrlb6vXkl1q0pXP/QdUkvHm2SsW6jIXKvDz9xsvs9Pt/R7tm8POgfUOzybcQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shaka-player/-/shaka-player-3.0.1.tgz",
+      "integrity": "sha512-sd//nbjJUlEZKRnGk6IBu0YW+Iw0ia8m5Zm4MxoL19VtDaiv0YuHo7ydFYkE3TcNOn++SCMQ+YntWtbNvRuQHw==",
+      "requires": {
+        "eme-encryption-scheme-polyfill": "^2.0.1"
+      }
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -10684,7 +10722,8 @@
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
     },
     "trim-newlines": {
       "version": "2.0.0",
@@ -10721,11 +10760,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
       "dev": true
-    },
-    "tsml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tsml/-/tsml-1.0.1.tgz",
-      "integrity": "sha1-ifghi52eJX9H1/a1bQHFpNLGj8M="
     },
     "tsmlb": {
       "version": "1.0.0",
@@ -11054,9 +11088,9 @@
       "dev": true
     },
     "url-toolkit": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.1.6.tgz",
-      "integrity": "sha512-UaZ2+50am4HwrV2crR/JAf63Q4VvPYphe63WGeoJxeu8gmOm0qxPt+KsukfakPNrX9aymGNEkkaoICwn+OuvBw=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.0.tgz",
+      "integrity": "sha512-Rde0c9S4fJK3FaHim3DSgdQ8IFrSXcZCpAJo9T7/FA+BoQGhK0ow3mpwGQLJCPYsNn6TstpW7/7DzMpSpz9F9w=="
     },
     "use": {
       "version": "3.1.1",
@@ -11130,24 +11164,24 @@
       }
     },
     "video.js": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-7.4.1.tgz",
-      "integrity": "sha512-UmTHiJWcil8YN65M1t/d63X6ofLtQwnvJoYEN4VKzkECYIHbgzvMRgOmrf5bNtVeDC6JsFKLZQXJ7s6Au2jgcQ==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-7.9.2.tgz",
+      "integrity": "sha512-yDQxyidSTt7z94NY9293C9yiS3BKvieIBPBi4a6V5wi2HjFCzCEPEPoBm7/ARQeGgf+/TswON3BMJnoLwVggLQ==",
       "requires": {
-        "@babel/runtime": "^7.2.0",
-        "@videojs/http-streaming": "1.5.1",
+        "@babel/runtime": "^7.9.2",
+        "@videojs/http-streaming": "1.13.3",
+        "@videojs/xhr": "2.5.1",
         "global": "4.3.2",
+        "keycode": "^2.2.0",
         "safe-json-parse": "4.0.0",
-        "tsml": "1.0.1",
-        "videojs-font": "3.1.0",
-        "videojs-vtt.js": "0.14.1",
-        "xhr": "2.4.0"
+        "videojs-font": "3.2.0",
+        "videojs-vtt.js": "^0.15.2"
       }
     },
     "videojs-font": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-3.1.0.tgz",
-      "integrity": "sha512-rxB68SVgbHD+kSwoNWNCHicKJuR2ga3bGfvGxmB+8fupsiLbnyCwTBVtrZUq4bZnD64mrKP1DxHiutxwrs59pQ=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-3.2.0.tgz",
+      "integrity": "sha512-g8vHMKK2/JGorSfqAZQUmYYNnXmfec4MLhwtEFS+mMs2IDY398GLysy6BH6K+aS1KMNu/xWZ8Sue/X/mdQPliA=="
     },
     "videojs-generate-karma-config": {
       "version": "5.0.2",
@@ -11233,9 +11267,9 @@
       }
     },
     "videojs-vtt.js": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.14.1.tgz",
-      "integrity": "sha512-YxOiywx6N9t3J5nqsE5WN2Sw4CSqVe3zV+AZm2T4syOc2buNJaD6ZoexSdeszx2sHLU/RRo2r4BJAXFDQ7Qo2Q==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.15.2.tgz",
+      "integrity": "sha512-kEo4hNMvu+6KhPvVYPKwESruwhHC3oFis133LwhXHO9U7nRnx0RiJYMiqbgwjgazDEXHR6t8oGJiHM6wq5XlAw==",
       "requires": {
         "global": "^4.3.1"
       }
@@ -11370,22 +11404,16 @@
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
       "dev": true
     },
-    "xhr": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.0.tgz",
-      "integrity": "sha1-4W5mpF+GmGHu76tBbV7/ci3ECZM=",
-      "requires": {
-        "global": "~4.3.0",
-        "is-function": "^1.0.1",
-        "parse-headers": "^2.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
     "xmlcreate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
       "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
       "dev": true
+    },
+    "xmldom": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
+      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",
@@ -11396,7 +11424,8 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -84,8 +84,8 @@
   "dependencies": {
     "global": "^4.3.2",
     "mux.js": "^5.5.1",
-    "shaka-player": "~2.4.7",
-    "video.js": "^6 || ^7"
+    "shaka-player": "^3.0.1",
+    "video.js": "^7.9.2"
   },
   "devDependencies": {
     "@videojs/generator-helpers": "~1.0.0",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -7,6 +7,9 @@ const Tech = videojs.getTech('Tech');
 // Register Shaka as a Tech;
 Tech.registerTech('Shaka', Shaka);
 
+// Register Shaka source handler
+videojs.getTech('Shaka').registerSourceHandler(Shaka.manifestSourceHandler, 0);
+
 // Register quality picker plugin
 const registerPlugin = videojs.registerPlugin || videojs.plugin;
 registerPlugin('qualityPickerPlugin', qualityPickerPlugin);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -11,6 +11,8 @@ shaka.polyfill.installAll();
 const defaults = {
     debug: false,
     drm: {},
+    enableDash: !videojs.browser.IS_ANY_SAFARI,
+    enableHls: true,
     overrideNative: !videojs.browser.IS_ANY_SAFARI
 }
 videojs.options.shaka = videojs.mergeOptions(defaults, videojs.options.shaka || {});

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -9,6 +9,7 @@ shaka.polyfill.installAll();
 
 // Create default options
 const defaults = {
+    autoInitQualityPicker: false,
     debug: false,
     drm: {},
     enableDash: true,

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -14,6 +14,7 @@ const defaults = {
     drm: {},
     enableDash: true,
     enableHls: true,
+    enableOther: true,
     overrideNative: !videojs.browser.IS_ANY_SAFARI
 }
 videojs.options.shaka = videojs.mergeOptions(defaults, videojs.options.shaka || {});

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -4,6 +4,17 @@ import qualityPickerPlugin from './quality-picker';
 
 const Tech = videojs.getTech('Tech');
 
+// Install built-in polyfills to patch browser incompatibilities.
+shaka.polyfill.installAll();
+
+// Create default options
+const defaults = {
+    debug: false,
+    drm: {},
+    overrideNative: !videojs.browser.IS_ANY_SAFARI
+}
+videojs.options.shaka = videojs.mergeOptions(defaults, videojs.options.shaka || {});
+
 // Register Shaka as a Tech;
 Tech.registerTech('Shaka', Shaka);
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -11,7 +11,7 @@ shaka.polyfill.installAll();
 const defaults = {
     debug: false,
     drm: {},
-    enableDash: !videojs.browser.IS_ANY_SAFARI,
+    enableDash: true,
     enableHls: true,
     overrideNative: !videojs.browser.IS_ANY_SAFARI
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -20,9 +20,6 @@ videojs.options.shaka = videojs.mergeOptions(defaults, videojs.options.shaka || 
 // Register Shaka as a Tech;
 Tech.registerTech('Shaka', Shaka);
 
-// Register Shaka source handler
-videojs.getTech('Shaka').registerSourceHandler(Shaka.manifestSourceHandler, 0);
-
 // Register quality picker plugin
 const registerPlugin = videojs.registerPlugin || videojs.plugin;
 registerPlugin('qualityPickerPlugin', qualityPickerPlugin);

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -203,7 +203,7 @@ Shaka.manifestSourceHandler.canUseDashType = function(type, options = {}) {
     const enableDash = (localOptions.shaka.enableDash == null) ? !videojs.browser.IS_ANY_SAFARI : localOptions.shaka.enableDash;
     const pattern = /^application\/dash\+xml/i;
     const result = enableDash && pattern.test(type);
-    shaka.log.debug('Shaka.manifestSourceHandler.canUseDashType | "' + result + '" | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
+    shaka.log.debug('Shaka.manifestSourceHandler.canUseDashType | "' + result + '" | ' + enableDash + ' | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
     return result;
 }
 
@@ -231,7 +231,7 @@ Shaka.manifestSourceHandler.canUseHlsType = function(type, options = {}) {
     });
 
     const result = enableHls && canPlayType;
-    shaka.log.debug('Shaka.manifestSourceHandler.canUseHlsType | "' + result + '" | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
+    shaka.log.debug('Shaka.manifestSourceHandler.canUseHlsType | "' + result + '" | ' + enableHls + ' | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
     return result;
 }
 

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -203,7 +203,7 @@ Shaka.manifestSourceHandler.canUseDashType = function(type, options = {}) {
     const enableDash = (localOptions.shaka.enableDash == null) ? !videojs.browser.IS_ANY_SAFARI : localOptions.shaka.enableDash;
     const pattern = /^application\/dash\+xml/i;
     const result = enableDash && pattern.test(type);
-    shaka.log.debug('Shaka.manifestSourceHandler.canUseDashType | "' + result + '" | ' + enableDash + ' | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
+    shaka.log.debug('Shaka.manifestSourceHandler.canUseDashType | ' + enableDash + ' | ' + result + ' | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
     return result;
 }
 
@@ -231,7 +231,7 @@ Shaka.manifestSourceHandler.canUseHlsType = function(type, options = {}) {
     });
 
     const result = enableHls && canPlayType;
-    shaka.log.debug('Shaka.manifestSourceHandler.canUseHlsType | "' + result + '" | ' + enableHls + ' | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
+    shaka.log.debug('Shaka.manifestSourceHandler.canUseHlsType | ' + enableHls + ' | ' + result + ' | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
     return result;
 }
 

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -240,19 +240,20 @@ Shaka.manifestSourceHandler.canHandleSource = function(source, options = {}, yes
     return result;
 };
 
+Shaka.manifestSourceHandler.isDashType = function(type) {
+    const pattern = /^application\/dash\+xml/i;
+    return pattern.test(type);
+};
+
 Shaka.manifestSourceHandler.canUseDashType = function(type, options = {}) {
     const localOptions = videojs.mergeOptions(videojs.options, options);
     const enableDash = (localOptions.shaka.enableDash == null) ? !videojs.browser.IS_ANY_SAFARI : localOptions.shaka.enableDash;
-    const pattern = /^application\/dash\+xml/i;
-    const result = enableDash && pattern.test(type);
+    const result = enableDash && Shaka.manifestSourceHandler.isDashType(type);
     shaka.log.debug('Shaka.manifestSourceHandler.canUseDashType | ' + enableDash + ' | ' + result + ' | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
     return result;
-}
+};
 
-Shaka.manifestSourceHandler.canUseHlsType = function(type, options = {}) {
-    const localOptions = videojs.mergeOptions(videojs.options, options);
-    const enableHls = localOptions.shaka.enableHls;
-    
+Shaka.manifestSourceHandler.isHlsType = function(type) {
     // HLS manifests can go by many mime-types
     const choices = [
         // Apple santioned
@@ -268,14 +269,18 @@ Shaka.manifestSourceHandler.canUseHlsType = function(type, options = {}) {
         'video/mpegurl',
         'application/mpegurl'
     ];
-    const canPlayType = choices.some(function(choice) {
+    return choices.some(function(choice) {
         return choice == type;
     });
+};
 
-    const result = enableHls && canPlayType;
+Shaka.manifestSourceHandler.canUseHlsType = function(type, options = {}) {
+    const localOptions = videojs.mergeOptions(videojs.options, options);
+    const enableHls = localOptions.shaka.enableHls;
+    const result = enableHls && Shaka.manifestSourceHandler.isHlsType(type);
     shaka.log.debug('Shaka.manifestSourceHandler.canUseHlsType | ' + enableHls + ' | ' + result + ' | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
     return result;
-}
+};
 
 Shaka.manifestSourceHandler.canPlayType = function(type, options = {}, yes = 'maybe') {
     const localOptions = videojs.mergeOptions(videojs.options, options);

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -212,8 +212,10 @@ Shaka.manifestSourceHandler = {};
 Shaka.manifestSourceHandler.canHandleSource = function(source, options = {}, yes = 'maybe') {
     const localOptions = videojs.mergeOptions(videojs.options, options);
     var type = '';
-    if (!source.src || /^blob\:/i.test(source.src)) {
-        /* do nothing */
+    if (!source.src) {
+        throw 'Invalid source "' + source.src + '" encountered.  The src attribute is required!'
+    } else if (/^blob\:/i.test(source.src)) {
+        throw 'Invalid source "' + source.src + '" encountered.  We cannot handle blob urls!'
     } else if (source.type) {
         type = source.type;
     } else {

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -251,4 +251,10 @@ Shaka.manifestSourceHandler.handleSource = function(source, tech, options) {
   tech.setSrc(source.src);
 };
 
+// Reset source handlers
+Shaka.sourceHandlers = [];
+
+// Register manifest source handler
+Shaka.registerSourceHandler(Shaka.manifestSourceHandler, 0);
+
 export default Shaka;

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -50,12 +50,12 @@ class Shaka extends Html5 {
     this.player_.ready(() => {
       this.player_.addClass('vjs-shaka');
       this.isReady = true;
-      this.autoQualityPicker();
+      this.initQualityPicker();
     });
   }
   
-  autoQualityPicker() {
-      if (this.isReady) {
+  initQualityPicker() {
+      if (this.isReady && this.vjsPlayer.options_.shaka.autoInitQualityPicker) {
           this.vjsPlayer.qualityPickerPlugin();
       }
   }
@@ -106,7 +106,7 @@ class Shaka extends Html5 {
       me.retriggerError(event.detail);
     });
     
-    this.autoQualityPicker()
+    this.initQualityPicker()
     this.shaka_.load(src).then(function() {
       me.initShakaMenus();
     }).catch(me.retriggerError.bind(this));

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -199,9 +199,9 @@ Shaka.canPlayType = function(type) {
  *        The options passed to the tech
  * @return {string} 'probably', 'maybe', or '' (empty string)
  */
-Shaka.canPlaySource = function(source, options) {
+Shaka.canPlaySource = function(source, options = {}) {
   const localOptions = videojs.mergeOptions(videojs.options, {shaka: options});
-  const result = Shaka.manifestSourceHandler.canHandleSource(source, localOptions);
+  const result = Shaka.manifestSourceHandler.canHandleSource(source, localOptions, 'probably');
   shaka.log.debug('Shaka.canPlaySource | ' + result + ' | ' + JSON.stringify(source, null, 2) + ' | ' + JSON.stringify(options, null, 2) + ' | ' + JSON.stringify(localOptions, null, 2));
   return result;
 };
@@ -209,7 +209,7 @@ Shaka.canPlaySource = function(source, options) {
 
 Shaka.manifestSourceHandler = {};
 
-Shaka.manifestSourceHandler.canHandleSource = function(source, options = {}) {
+Shaka.manifestSourceHandler.canHandleSource = function(source, options = {}, yes = 'maybe') {
     const localOptions = videojs.mergeOptions(videojs.options, options);
     var type = '';
     if (!source.src || /^blob\:/i.test(source.src)) {
@@ -223,7 +223,7 @@ Shaka.manifestSourceHandler.canHandleSource = function(source, options = {}) {
             type = 'application/vnd.apple.mpegurl'
         }
     }
-    const result = Shaka.manifestSourceHandler.canPlayType(type, localOptions);
+    const result = Shaka.manifestSourceHandler.canPlayType(type, localOptions, yes);
     shaka.log.debug('Shaka.manifestSourceHandler.canHandleSource | "' + result + '" | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
     return result;
 };
@@ -265,13 +265,13 @@ Shaka.manifestSourceHandler.canUseHlsType = function(type, options = {}) {
     return result;
 }
 
-Shaka.manifestSourceHandler.canPlayType = function(type, options = {}) {
+Shaka.manifestSourceHandler.canPlayType = function(type, options = {}, yes = 'maybe') {
     const localOptions = videojs.mergeOptions(videojs.options, options);
     const overrideNative = localOptions.shaka.overrideNative;
     const canUseDash = Shaka.manifestSourceHandler.canUseDashType(type, localOptions);
     const canUseHls = Shaka.manifestSourceHandler.canUseHlsType(type, localOptions);
     const canUse = (canUseDash || canUseHls) && Shaka.isSupported() && (!Shaka.supportsTypeNatively(type) || overrideNative);
-    const result = canUse ? 'maybe' : '';
+    const result = canUse ? yes : '';
     shaka.log.debug('Shaka.manifestSourceHandler.canPlayType | "' + result + '" | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
     return result;
 };

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -177,6 +177,36 @@ Shaka.supportsTypeNatively = function(type) {
     return result;
 };
 
+/**
+ * Check if the tech can support the given type
+ *
+ * @param {string} type
+ *        The mimetype to check
+ * @return {string} 'probably', 'maybe', or '' (empty string)
+ */
+Shaka.canPlayType = function(type) {
+  const result = Shaka.manifestSourceHandler.canPlayType(type);
+  shaka.log.debug('Shaka.canPlayType | ' + type + ' | ' + result);
+  return result
+};
+
+/**
+ * Check if the tech can support the given source
+ *
+ * @param {Object} source
+ *        The source object
+ * @param {Object} options
+ *        The options passed to the tech
+ * @return {string} 'probably', 'maybe', or '' (empty string)
+ */
+Shaka.canPlaySource = function(source, options) {
+  const localOptions = videojs.mergeOptions(videojs.options, {shaka: options});
+  const result = Shaka.manifestSourceHandler.canHandleSource(source, localOptions);
+  shaka.log.debug('Shaka.canPlaySource | ' + result + ' | ' + JSON.stringify(source, null, 2) + ' | ' + JSON.stringify(options, null, 2) + ' | ' + JSON.stringify(localOptions, null, 2));
+  return result;
+};
+
+
 Shaka.manifestSourceHandler = {};
 
 Shaka.manifestSourceHandler.canHandleSource = function(source, options = {}) {

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -43,6 +43,8 @@ class Shaka extends Html5 {
     super(options, ready);
 
     this.vjsPlayer = videojs(options.playerId);
+    
+    shaka.log.debug('Shaka.constructor | ' + JSON.stringify(this.vjsPlayer.options_, null, 2));
 
     this.player_.ready(() => {
       this.player_.addClass('vjs-shaka');
@@ -68,8 +70,8 @@ class Shaka extends Html5 {
   }
 
   setSrc(src) {
-
     const me = this;
+    shaka.log.debug('Shaka.setSrc | ' + src + ' | ' + JSON.stringify(me.options_, null, 2));
 
     let drm;
     if (typeof this.options_.drm === 'function') {

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -198,11 +198,30 @@ Shaka.manifestSourceHandler.canHandleSource = function(source, options = {}) {
     return result;
 };
 
+Shaka.manifestSourceHandler.canUseDashType = function(type, options = {}) {
+    const localOptions = videojs.mergeOptions(videojs.options, options);
+    const enableDash = localOptions.shaka.enableDash;
+    const pattern = /^application\/dash\+xml/i;
+    const result = enableDash && pattern.test(type);
+    shaka.log.debug('Shaka.manifestSourceHandler.canUseDashType | "' + result + '" | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
+    return result;
+}
+
+Shaka.manifestSourceHandler.canUseHlsType = function(type, options = {}) {
+    const localOptions = videojs.mergeOptions(videojs.options, options);
+    const enableHls = localOptions.shaka.enableHls;
+    const pattern = /^(application\/x-mpegURL|application\/vnd.apple.mpegurl)/i;
+    const result = enableHls && pattern.test(type);
+    shaka.log.debug('Shaka.manifestSourceHandler.canUseHlsType | "' + result + '" | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
+    return result;
+}
+
 Shaka.manifestSourceHandler.canPlayType = function(type, options = {}) {
     const localOptions = videojs.mergeOptions(videojs.options, options);
     const overrideNative = localOptions.shaka.overrideNative;
-    const pattern = /^(application\/dash\+xml|application\/x-mpegURL|application\/vnd.apple.mpegurl)/i;
-    const canUse = pattern.test(type) && Shaka.isSupported() && (!Shaka.supportsTypeNatively(type) || overrideNative);
+    const canUseDash = Shaka.manifestSourceHandler.canUseDashType(type, localOptions);
+    const canUseHls = Shaka.manifestSourceHandler.canUseHlsType(type, localOptions);
+    const canUse = (canUseDash || canUseHls) && Shaka.isSupported() && (!Shaka.supportsTypeNatively(type) || overrideNative);
     const result = canUse ? 'maybe' : '';
     shaka.log.debug('Shaka.manifestSourceHandler.canPlayType | "' + result + '" | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
     return result;

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -43,12 +43,21 @@ class Shaka extends Html5 {
     super(options, ready);
 
     this.vjsPlayer = videojs(options.playerId);
+    this.isReady = false
     
     shaka.log.debug('Shaka.constructor | ' + JSON.stringify(this.vjsPlayer.options_, null, 2));
 
     this.player_.ready(() => {
       this.player_.addClass('vjs-shaka');
+      this.isReady = true;
+      this.autoQualityPicker();
     });
+  }
+  
+  autoQualityPicker() {
+      if (this.isReady) {
+          this.vjsPlayer.qualityPickerPlugin();
+      }
   }
 
   createEl() {
@@ -96,7 +105,8 @@ class Shaka extends Html5 {
     this.shaka_.addEventListener('error', function(event) {
       me.retriggerError(event.detail);
     });
-
+    
+    this.autoQualityPicker()
     this.shaka_.load(src).then(function() {
       me.initShakaMenus();
     }).catch(me.retriggerError.bind(this));

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -170,7 +170,9 @@ Shaka.isSupported = function() {
 
 Shaka.supportsTypeNatively = function(type) {
     const video = document.createElement('video');
-    return video.canPlayType(type) != '';
+    const result = video.canPlayType(type) != '';
+    shaka.log.debug('Shaka.supportsTypeNatively | ' + type + ' | ' + result);
+    return result;
 };
 
 Shaka.manifestSourceHandler = {};
@@ -190,7 +192,7 @@ Shaka.manifestSourceHandler.canHandleSource = function(source, options = {}) {
         }
     }
     const result = Shaka.manifestSourceHandler.canPlayType(type, localOptions);
-    shaka.log.debug('Shaka.manifestSourceHandler.canHandleSource | "' + result + '" | ' + type + ' | ' + JSON.stringify(localOptions));
+    shaka.log.debug('Shaka.manifestSourceHandler.canHandleSource | "' + result + '" | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
     return result;
 };
 
@@ -200,7 +202,7 @@ Shaka.manifestSourceHandler.canPlayType = function(type, options = {}) {
     const pattern = /^(application\/dash\+xml|application\/x-mpegURL|application\/vnd.apple.mpegurl)/i;
     const canUse = pattern.test(type) && Shaka.isSupported() && (!Shaka.supportsTypeNatively(type) || overrideNative);
     const result = canUse ? 'maybe' : '';
-    shaka.log.debug('Shaka.manifestSourceHandler.canPlayType | "' + result + '" | ' + type + ' | ' + JSON.stringify(localOptions));
+    shaka.log.debug('Shaka.manifestSourceHandler.canPlayType | "' + result + '" | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
     return result;
 };
 

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -210,8 +210,27 @@ Shaka.manifestSourceHandler.canUseDashType = function(type, options = {}) {
 Shaka.manifestSourceHandler.canUseHlsType = function(type, options = {}) {
     const localOptions = videojs.mergeOptions(videojs.options, options);
     const enableHls = localOptions.shaka.enableHls;
-    const pattern = /^(application\/x-mpegURL|application\/vnd.apple.mpegurl)/i;
-    const result = enableHls && pattern.test(type);
+    
+    // HLS manifests can go by many mime-types
+    const choices = [
+        // Apple santioned
+        'application/vnd.apple.mpegurl',
+        // Apple sanctioned for backwards compatibility
+        'audio/mpegurl',
+        // Very common
+        'audio/x-mpegurl',
+        // Very common
+        'application/x-mpegurl',
+        // Included for completeness
+        'video/x-mpegurl',
+        'video/mpegurl',
+        'application/mpegurl'
+    ];
+    const canPlayType = choices.some(function(choice) {
+        return choice == type;
+    });
+
+    const result = enableHls && canPlayType;
     shaka.log.debug('Shaka.manifestSourceHandler.canUseHlsType | "' + result + '" | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));
     return result;
 }

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -200,7 +200,7 @@ Shaka.canPlayType = function(type) {
  * @return {string} 'probably', 'maybe', or '' (empty string)
  */
 Shaka.canPlaySource = function(source, options = {}) {
-  const localOptions = videojs.mergeOptions(videojs.options, {shaka: options});
+  const localOptions = {shaka: options};
   const result = Shaka.manifestSourceHandler.canHandleSource(source, localOptions, 'probably');
   shaka.log.debug('Shaka.canPlaySource | ' + result + ' | ' + JSON.stringify(source, null, 2) + ' | ' + JSON.stringify(options, null, 2) + ' | ' + JSON.stringify(localOptions, null, 2));
   return result;

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -200,7 +200,7 @@ Shaka.manifestSourceHandler.canHandleSource = function(source, options = {}) {
 
 Shaka.manifestSourceHandler.canUseDashType = function(type, options = {}) {
     const localOptions = videojs.mergeOptions(videojs.options, options);
-    const enableDash = localOptions.shaka.enableDash;
+    const enableDash = (localOptions.shaka.enableDash == null) ? !videojs.browser.IS_ANY_SAFARI : localOptions.shaka.enableDash;
     const pattern = /^application\/dash\+xml/i;
     const result = enableDash && pattern.test(type);
     shaka.log.debug('Shaka.manifestSourceHandler.canUseDashType | "' + result + '" | ' + type + ' | ' + JSON.stringify(localOptions, null, 2));

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -182,4 +182,32 @@ Shaka.canPlaySource = function(source, tech) {
   return '';
 };
 
+Shaka.manifestSourceHandler = {};
+Shaka.manifestSourceHandler.canHandleSource = function(source, options) {
+    // If a type was provided we should rely on that
+    if (source.type) {
+        return Shaka.manifestSourceHandler.canPlayType(source.type);
+    
+    } else if (source.src) {
+        const pattern = /(\.mpd|\.m3u8)/i;
+        if (pattern.test(source.src)) {
+            return 'probably';
+        }
+    }
+    
+    return '';
+};
+Shaka.manifestSourceHandler.canPlayType = function(type) {
+    const pattern = /^(application\/dash\+xml|application\/x-mpegURL|application\/vnd\.apple\.mpegurl)/i;
+    
+    if (pattern.test(type)) {
+        return 'probably';
+    }
+    
+    return '';
+}
+Shaka.manifestSourceHandler.handleSource = function(source, tech, options) {
+  tech.setSrc(source.src);
+}
+
 export default Shaka;

--- a/src/shaka.js
+++ b/src/shaka.js
@@ -171,18 +171,8 @@ Shaka.isSupported = function() {
   return !!window.MediaSource;
 };
 
-Shaka.canPlaySource = function(source, tech) {
-
-  const dashTypeRE = /^(application\/dash\+xml|application\/x-mpegURL)/i;
-
-  if (dashTypeRE.test(source.type)) {
-    return 'probably';
-  }
-
-  return '';
-};
-
 Shaka.manifestSourceHandler = {};
+
 Shaka.manifestSourceHandler.canHandleSource = function(source, options) {
     // If a type was provided we should rely on that
     if (source.type) {
@@ -197,17 +187,19 @@ Shaka.manifestSourceHandler.canHandleSource = function(source, options) {
     
     return '';
 };
+
 Shaka.manifestSourceHandler.canPlayType = function(type) {
-    const pattern = /^(application\/dash\+xml|application\/x-mpegURL|application\/vnd\.apple\.mpegurl)/i;
+    const pattern = /^(application\/dash\+xml|application\/x-mpegURL|application\/vnd.apple.mpegurl)/i;
     
     if (pattern.test(type)) {
         return 'probably';
     }
     
     return '';
-}
+};
+
 Shaka.manifestSourceHandler.handleSource = function(source, tech, options) {
   tech.setSrc(source.src);
-}
+};
 
 export default Shaka;

--- a/vagrant/.gitignore
+++ b/vagrant/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/vagrant/README
+++ b/vagrant/README
@@ -8,5 +8,10 @@ To run tests:
         vagrant up
         vagrant ssh
         cd /vagrant
+        
+        # note: `npm install` is slow - if you are using eclipse, it is helpful to
+        # exclude node_modules from the package explorer - let it complete because
+        # cancelling execution mid installation will cause you nightmares
+        
         npm install
         npm run sample

--- a/vagrant/README
+++ b/vagrant/README
@@ -1,17 +1,13 @@
 CREATES A VAGRANT ENVIRONMENT TO FACILITATE LOCAL TESTING
 
+note: `vagrant up` is slow - go make coffee
+note: if you are using eclipse, exclude node_modules from the package explorer
+
 ========
 USAGE:
 ========
-To run tests:
-    cd to this directory and then issue the following commands:
+    cd to this directory and then issue the following commands:    
         vagrant up
         vagrant ssh
         cd /vagrant
-        
-        # note: `npm install` is slow - if you are using eclipse, it is helpful to
-        # exclude node_modules from the package explorer - let it complete because
-        # cancelling execution mid installation will cause you nightmares
-        
-        npm install
         npm run sample

--- a/vagrant/README
+++ b/vagrant/README
@@ -1,0 +1,12 @@
+CREATES A VAGRANT ENVIRONMENT TO FACILITATE LOCAL TESTING
+
+========
+USAGE:
+========
+To run tests:
+    cd to this directory and then issue the following commands:
+        vagrant up
+        vagrant ssh
+        cd /vagrant
+        npm install
+        npm run sample

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -14,8 +14,6 @@ Vagrant.configure("2") do |config|
     
     config.vm.provider "virtualbox" do |v|
       v.name = "videojs-shaka"
-      v.memory = 4096
-      v.cpus = 4
       v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
     end
     

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -5,7 +5,6 @@ Vagrant.configure("2") do |config|
       v.name = "videojs-shaka"
       v.memory = 4096
       v.cpus = 4
-      v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
     end
     
     config.vm.network "forwarded_port", guest: 3000, host: 3000

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -5,6 +5,7 @@ Vagrant.configure("2") do |config|
       v.name = "videojs-shaka"
       v.memory = 4096
       v.cpus = 4
+      v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
     end
     
     config.vm.network "forwarded_port", guest: 3000, host: 3000

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,24 +1,16 @@
-if Vagrant::Util::Platform.windows? then
-  def running_in_admin_mode?
-    (`reg query HKU\\S-1-5-19 2>&1` =~ /ERROR/).nil?
-  end
- 
-  unless running_in_admin_mode?
-    puts "This vagrant makes use of SymLinks to the host. On Windows, Administrative privileges are required to create symlinks (mklink.exe). Try again from an Administrative command prompt."
-    exit 1
-  end
-end
-
 Vagrant.configure("2") do |config|
     config.vm.box = "hashicorp/bionic64"
     
     config.vm.provider "virtualbox" do |v|
       v.name = "videojs-shaka"
-      v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
     end
     
     config.vm.network "forwarded_port", guest: 3000, host: 3000
     config.vm.provision :shell, path: "provision/system.sh"
     config.vm.synced_folder ".", "/vagrant", disabled: true
-    config.vm.synced_folder "../", "/vagrant"
+    if Vagrant::Util::Platform.windows? then
+        config.vm.synced_folder "../", "/vagrant", type: 'smb', mount_options: ["mfsymlinks"]
+    else
+        config.vm.synced_folder "../", "/vagrant"
+    end
 end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,3 +1,14 @@
+if Vagrant::Util::Platform.windows? then
+  def running_in_admin_mode?
+    (`reg query HKU\\S-1-5-19 2>&1` =~ /ERROR/).nil?
+  end
+ 
+  unless running_in_admin_mode?
+    puts "This vagrant makes use of SymLinks to the host. On Windows, Administrative privileges are required to create symlinks (mklink.exe). Try again from an Administrative command prompt."
+    exit 1
+  end
+end
+
 Vagrant.configure("2") do |config|
     config.vm.box = "hashicorp/bionic64"
     
@@ -5,6 +16,7 @@ Vagrant.configure("2") do |config|
       v.name = "videojs-shaka"
       v.memory = 4096
       v.cpus = 4
+      v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
     end
     
     config.vm.network "forwarded_port", guest: 3000, host: 3000

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,14 @@
+Vagrant.configure("2") do |config|
+    config.vm.box = "hashicorp/bionic64"
+    
+    config.vm.provider "virtualbox" do |v|
+      v.name = "videojs-shaka"
+      v.memory = 4096
+      v.cpus = 4
+    end
+    
+    config.vm.network "forwarded_port", guest: 3000, host: 3000
+    config.vm.provision :shell, path: "provision/system.sh"
+    config.vm.synced_folder ".", "/vagrant", disabled: true
+    config.vm.synced_folder "../", "/vagrant"
+end

--- a/vagrant/provision/system.sh
+++ b/vagrant/provision/system.sh
@@ -6,5 +6,5 @@ set -o xtrace
 
 export DEBIAN_FRONTEND=noninteractive
 
-curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
 apt-get install -y build-essential nodejs

--- a/vagrant/provision/system.sh
+++ b/vagrant/provision/system.sh
@@ -11,4 +11,4 @@ apt-get install -y build-essential nodejs
 
 cd /vagrant
 su vagrant
-npm ci --no-bin-links
+npm ci

--- a/vagrant/provision/system.sh
+++ b/vagrant/provision/system.sh
@@ -8,3 +8,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 apt-get install -y build-essential nodejs
+
+cd /vagrant
+su vagrant
+npm ci

--- a/vagrant/provision/system.sh
+++ b/vagrant/provision/system.sh
@@ -1,0 +1,10 @@
+set -o errexit
+set -o pipefail
+set -o nounset
+shopt -s failglob
+set -o xtrace
+
+export DEBIAN_FRONTEND=noninteractive
+
+curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+apt-get install -y build-essential nodejs

--- a/vagrant/provision/system.sh
+++ b/vagrant/provision/system.sh
@@ -11,4 +11,4 @@ apt-get install -y build-essential nodejs
 
 cd /vagrant
 su vagrant
-npm ci
+npm ci --no-bin-links

--- a/vagrant/provision/system.sh
+++ b/vagrant/provision/system.sh
@@ -6,5 +6,5 @@ set -o xtrace
 
 export DEBIAN_FRONTEND=noninteractive
 
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 apt-get install -y build-essential nodejs


### PR DESCRIPTION
Adds native playback along with the previous PRs.

Since shaka is capable of handling native playback, this tech can support the usecase.  This allows omitting the videojs html5 tech and still being able to playback progressive download content in the browser.

Useful for cases were you want to avoid videojs's default playback of HLS and DASH content which cannot be disabled

reference https://github.com/videojs/http-streaming/issues/917